### PR TITLE
feat: add Laravel 12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^10.0|^11.0",
-        "illuminate/view": "^10.0|^11.0"
+        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/view": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.9",


### PR DESCRIPTION
## Summary
Adds support for Laravel 12 by updating the illuminate/support and illuminate/view dependency constraints.

## Changes
- Updated `illuminate/support` constraint from `^10.0|^11.0` to `^10.0|^11.0|^12.0`
- Updated `illuminate/view` constraint from `^10.0|^11.0` to `^10.0|^11.0|^12.0`

## Testing
- [x] Package installs successfully with Laravel 12
- [x] Components render correctly with Laravel 12

## Compatibility
This change maintains backward compatibility with Laravel 10 and 11 while adding support for Laravel 12.

## Motivation
Laravel 12 has been released and projects using this framework version cannot currently use this package due to the dependency constraints.